### PR TITLE
Full season schedule api

### DIFF
--- a/app/models/football_game.rb
+++ b/app/models/football_game.rb
@@ -1,0 +1,12 @@
+class FootballGame
+  attr_reader :id, :week, :date, :awayTeam, :homeTeam, :location
+
+  def initialize(attrs)
+    @id       = attrs[:id]
+    @week     = attrs[:week]
+    @date     = attrs[:date]
+    @awayTeam = attrs[:awayTeam]
+    @homeTeam = attrs[:homeTeam]
+    @location = attrs[:location]
+  end
+end

--- a/app/models/football_player.rb
+++ b/app/models/football_player.rb
@@ -1,0 +1,2 @@
+class FootballPlayer < ApplicationRecord
+end

--- a/app/models/game_schedule.rb
+++ b/app/models/game_schedule.rb
@@ -1,16 +1,23 @@
 class GameSchedule
-  attr_reader :games
+  attr_reader :games, :seasons
 
   def initialize
     @games = []
+    @seasons = ['2014-2014-regular', '2015-2015-regular', '2016-2016-regular']
   end
 
   def store_schedule
     service = SportsFeedService.new
-    results = service.full_season_schedule
-    games   = results[:fullgameschedule][:gameentry]
-    @games = games.map do |game_details|
-      FootballGame.new(game_details)
+
+    seasons.each do |season|
+      results = service.full_season_schedule(season)
+      games   = results[:fullgameschedule][:gameentry]
+      games.each do |game_details|
+        @games << FootballGame.new(game_details)
+      end
+      # @games = games.map do |game_details|
+      #   FootballGame.new(game_details)
+      # end
     end
   end
 end

--- a/app/models/game_schedule.rb
+++ b/app/models/game_schedule.rb
@@ -1,0 +1,16 @@
+class GameSchedule
+  attr_reader :games
+
+  def initialize
+    @games = []
+  end
+
+  def store_schedule
+    service = SportsFeedService.new
+    results = service.full_season_schedule
+    games   = results[:fullgameschedule][:gameentry]
+    @games = games.map do |game_details|
+      FootballGame.new(game_details)
+    end
+  end
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,0 +1,13 @@
+class Player
+  attr_reader :id, :last_name, :first_name, :position
+  attr_accessor :stats
+
+  def initialize(attrs)
+    @id         = attrs[:ID]
+    @last_name  = attrs[:LastName]
+    @first_name = attrs[:FirstName]
+    @position   = attrs[:Position]
+    @stats = []
+  end
+
+end

--- a/app/models/player_stats.rb
+++ b/app/models/player_stats.rb
@@ -1,0 +1,34 @@
+class PlayerStats
+  attr_reader :pass_yards, :pass_tds, :pass_ints, :rush_yards, :rush_tds,
+              :receptions, :rec_yards, :fum_lost, :kick_ret_td, :punt_ret_td
+
+  def initialize(attrs)
+    @pass_yards  = attrs[:PassYards]
+    @pass_tds    = attrs[:PassTD]
+    @pass_ints   = attrs[:PassInt]
+    @rush_yards  = attrs[:RushYards]
+    @rush_tds    = attrs[:RushTD]
+    @receptions  = attrs[:Receptions]
+    @rec_yards   = attrs[:RecYards]
+    @fum_lost    = attrs[:FumLost]
+    @kick_ret_td = attrs[:KrTD]
+    @punt_ret_td = attrs[:PrTD]
+  end
+
+end
+
+# 300+ Passing Yards	3	0
+# 100+ Yard Receiving Game	3	0
+# 2 Point Conversion	2	2
+# Sack	1	1
+# Interception	2	2
+# Fumble Recovery	2	2
+# Safety	2	2
+# Blocked Kick	2	2
+# 0 Pts Allowed	10	10
+# 1-6 Points Allowed	7	7
+# 7-13 Pts Allowed	4	4
+# 14-20 Pts Allowed	1	1
+# 21-27 Pts Allowed	0	0
+# 28-34 Pts Allowed	-1	-1
+# 35+ Pts Allowed	-4	-4

--- a/app/services/sports_feed_service.rb
+++ b/app/services/sports_feed_service.rb
@@ -1,0 +1,34 @@
+require 'base64'
+require 'faraday'
+require 'json'
+require 'pry'
+
+class SportsFeedService
+
+  def initialize
+    
+  end
+
+  def full_season_schedule
+    sports_feed_login = 'rongxanh88'
+    sports_feed_pw    = 'avsrule'
+    # https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/full_game_schedule
+    # authorization = "#{ENV['sports_feed_login']}:#{ENV['sports_feed_pw']}"
+    authorization = "#{sports_feed_login}:#{sports_feed_pw}"
+    encoded_authorization = Base64.encode64(authorization)
+    season_name = "2014-2017-regular"
+    url = "https://api.mysportsfeeds.com/v1.1/pull/nfl/#{season_name}/full_game_schedule.json"
+    # binding.pry
+    conn = Faraday.new(url: url)
+
+    response = conn.get do |req|
+      req.headers['Authorization'] = "Basic #{encoded_authorization}"
+    end
+
+    JSON.parse(response.body)
+  end
+end
+
+service = SportsFeedService.new
+result = service.full_season_schedule
+binding.pry

--- a/app/services/sports_feed_service.rb
+++ b/app/services/sports_feed_service.rb
@@ -10,23 +10,26 @@ class SportsFeedService
     pw    = ENV['sports_feed_pw']
     authorization = "#{login}:#{pw}"
     encoded_authorization = Base64.encode64(authorization)
-
     @conn  = Faraday.new(url: "https://api.mysportsfeeds.com")
     @conn.headers['Authorization'] = "Basic #{encoded_authorization}"
     # @conn.headers['Accept-Encoding'] = 'gzip'
     #need to decode gzipped responses
   end
 
-  def full_season_schedule
-    season_name = "2014-2014-regular"
-    url = "/v1.1/pull/nfl/#{season_name}/full_game_schedule.json"
+  def full_season_schedule(season)
+    url = "/v1.1/pull/nfl/#{season}/full_game_schedule.json"
     response = conn.get(url)
     
     JSON.parse(response.body, symbolize_names: true)
   end
   
   def daily_player_stats(date)
-    season = "2014-2014-regular"
+    year = date[0..3]
+    month = date[4..5]
+    if month == "01"
+      year = (year.to_i - 1).to_s
+    end
+    season = "#{year}-#{year}-regular"
     positions = 'qb,wr,rb,te'
     url = "/v1.1/pull/nfl/#{season}/daily_player_stats.json?fordate=#{date}&position=#{positions}"
     response = conn.get(url)
@@ -35,5 +38,5 @@ class SportsFeedService
   end
 
   private
-    attr_reader:conn
+    attr_reader :conn
 end

--- a/app/services/sports_feed_service.rb
+++ b/app/services/sports_feed_service.rb
@@ -6,32 +6,34 @@ require 'pry'
 class SportsFeedService
 
   def initialize
-    @login = ENV['sports_feed_login']
-    @pw    = ENV['sports_feed_pw']
-    @conn  = Faraday.new(url: "https://api.mysportsfeeds.com/v1.1/pull/nfl")
+    login = ENV['sports_feed_login']
+    pw    = ENV['sports_feed_pw']
+    authorization = "#{login}:#{pw}"
+    encoded_authorization = Base64.encode64(authorization)
+
+    @conn  = Faraday.new(url: "https://api.mysportsfeeds.com")
+    @conn.headers['Authorization'] = "Basic #{encoded_authorization}"
+    # @conn.headers['Accept-Encoding'] = 'gzip'
+    #need to decode gzipped responses
   end
 
   def full_season_schedule
-    # https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/full_game_schedule
-    authorization = "#{login}:#{pw}"
-    encoded_authorization = Base64.encode64(authorization)
     season_name = "2014-2014-regular"
-    url = "https://api.mysportsfeeds.com/v1.1/pull/nfl/#{season_name}/full_game_schedule.json"
-    # conn = Faraday.new(url: url)
+    url = "/v1.1/pull/nfl/#{season_name}/full_game_schedule.json"
+    response = conn.get(url)
+    
+    JSON.parse(response.body, symbolize_names: true)
+  end
+  
+  def daily_player_stats(date)
+    season = "2014-2014-regular"
+    positions = 'qb,wr,rb,te'
+    url = "/v1.1/pull/nfl/#{season}/daily_player_stats.json?fordate=#{date}&position=#{positions}"
+    response = conn.get(url)
 
-    response = conn.get do |req|
-      req.headers['Authorization'] = "Basic #{encoded_authorization}"
-      # req.headers['Accept-Encoding'] = 'gzip'
-    end
-
-    #need to decode gzipped responses
     JSON.parse(response.body, symbolize_names: true)
   end
 
-  def daily_player_stats(date)
-    url = "https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/daily_player_stats.{format}?fordate={for-date}"
-  end
-
   private
-    attr_reader :login, :pw
+    attr_reader:conn
 end

--- a/app/services/sports_feed_service.rb
+++ b/app/services/sports_feed_service.rb
@@ -6,29 +6,32 @@ require 'pry'
 class SportsFeedService
 
   def initialize
-    
+    @login = ENV['sports_feed_login']
+    @pw    = ENV['sports_feed_pw']
+    @conn  = Faraday.new(url: "https://api.mysportsfeeds.com/v1.1/pull/nfl")
   end
 
   def full_season_schedule
-    sports_feed_login = 'rongxanh88'
-    sports_feed_pw    = 'avsrule'
     # https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/full_game_schedule
-    # authorization = "#{ENV['sports_feed_login']}:#{ENV['sports_feed_pw']}"
-    authorization = "#{sports_feed_login}:#{sports_feed_pw}"
+    authorization = "#{login}:#{pw}"
     encoded_authorization = Base64.encode64(authorization)
-    season_name = "2014-2017-regular"
+    season_name = "2014-2014-regular"
     url = "https://api.mysportsfeeds.com/v1.1/pull/nfl/#{season_name}/full_game_schedule.json"
-    # binding.pry
-    conn = Faraday.new(url: url)
+    # conn = Faraday.new(url: url)
 
     response = conn.get do |req|
       req.headers['Authorization'] = "Basic #{encoded_authorization}"
+      # req.headers['Accept-Encoding'] = 'gzip'
     end
 
-    JSON.parse(response.body)
+    #need to decode gzipped responses
+    JSON.parse(response.body, symbolize_names: true)
   end
-end
 
-service = SportsFeedService.new
-result = service.full_season_schedule
-binding.pry
+  def daily_player_stats(date)
+    url = "https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/daily_player_stats.{format}?fordate={for-date}"
+  end
+
+  private
+    attr_reader :login, :pw
+end

--- a/db/migrate/20170904214919_create_football_players.rb
+++ b/db/migrate/20170904214919_create_football_players.rb
@@ -1,0 +1,13 @@
+class CreateFootballPlayers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :football_players do |t|
+      t.text :api_id
+      t.text :first_name
+      t.text :last_name
+      t.text :position
+      t.decimal :expected_point_production
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20170904214919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "football_players", force: :cascade do |t|
+    t.text "api_id"
+    t.text "first_name"
+    t.text "last_name"
+    t.text "position"
+    t.decimal "expected_point_production"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,21 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'pry'
+
+class Seed
+
+  def self.start
+    schedule = GameSchedule.new
+    schedule.store_schedule
+    #from here, we need to make an api call to get player stats?
+    games_by_date = schedule.games.uniq {|game| game.date}
+    dates = games_by_date.map {|game| game.date.gsub('-', '')}     
+
+    #https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/daily_player_stats.{format}?fordate={for-date}
+
+    #fordate={for-date}	a valid date in the form of YYYYMMDD
+    #position={list-of-positions} we want qb, wr, rb, te, DEF?
+
+    binding.pry
+  end
+end
+
+Seed.start

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,12 +7,13 @@ class Seed
     schedule.store_schedule
     #from here, we need to make an api call to get player stats?
     games_by_date = schedule.games.uniq {|game| game.date}
-    dates = games_by_date.map {|game| game.date.gsub('-', '')}     
-
-    #https://api.mysportsfeeds.com/v1.1/pull/nfl/{season-name}/daily_player_stats.{format}?fordate={for-date}
-
-    #fordate={for-date}	a valid date in the form of YYYYMMDD
-    #position={list-of-positions} we want qb, wr, rb, te, DEF?
+    dates = games_by_date.map {|game| game.date.gsub('-', '')}
+    service = SportsFeedService.new
+    dates.each do |date|
+      player_stats = service.daily_player_stats(date)
+      stats = player_stats[:dailyplayerstats][:playerstatsentry]
+      binding.pry
+    end
 
     binding.pry
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,23 @@ require 'pry'
 
 class Seed
 
+  FANTASY_POINTS = {
+    "pass_tds": 4,
+    "pass_yards": 0.04,
+    "pass_ints": -1,
+    "rec_tds": 6,
+    "rec_yards": 0.1,
+    "receptions": 1,
+    "rush_tds": 6,
+    "rush_yards": 0.1,
+    "punt_ret_td": 6,
+    "kick_ret_td": 6,
+    "fum_lost": -1
+  }
+
+  # 300+ Passing Yards	3	0
+  # 100+ Yard Receiving Game	3	0
+
   def self.start
     schedule = GameSchedule.new
     schedule.store_schedule
@@ -24,7 +41,21 @@ class Seed
       puts "All stats for date: #{date} memoized\r"
     end
     puts "All stats done\r"
-    binding.pry
+
+    # players.each do |id, player|
+    #   binding.pry
+
+    #   football_player = FootballPlayer.new(
+    #     api_id: id, first_name: player.first_name, last_name: player.last_name,
+    #     position: player.position
+    #     )
+
+    #   player.stats.each do |stat|
+    #     expected_production = 0
+
+    #   end
+    # end
+    # binding.pry
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,16 +5,25 @@ class Seed
   def self.start
     schedule = GameSchedule.new
     schedule.store_schedule
-    #from here, we need to make an api call to get player stats?
     games_by_date = schedule.games.uniq {|game| game.date}
     dates = games_by_date.map {|game| game.date.gsub('-', '')}
     service = SportsFeedService.new
+    players = {}
     dates.each do |date|
       player_stats = service.daily_player_stats(date)
       stats = player_stats[:dailyplayerstats][:playerstatsentry]
-      binding.pry
-    end
 
+      stats.each do |stat|
+        player_id = stat[:player][:ID]
+        player = players[player_id] || Player.new(stat[:player])
+        player_stat = PlayerStats.new(stat[:stats])
+        player.stats << player_stat
+        players[player_id] = player
+        puts "Add player ID: #{player_id} stats\r"
+      end
+      puts "All stats for date: #{date} memoized\r"
+    end
+    puts "All stats done\r"
     binding.pry
   end
 end

--- a/spec/factories/football_players.rb
+++ b/spec/factories/football_players.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :football_player do
+    
+  end
+end

--- a/spec/models/football_player_spec.rb
+++ b/spec/models/football_player_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FootballPlayer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
YES

## Description
This PR completes API request to get full game schedules for 2014-2016 seasons. That provides (256 * 3) games worth of data. From there, I get stats for players that play on the day of the game. Next up is to calculate fantasy point production, as well as other possible statistical measures and store them in the DB.

## Related PRs
List related PRs against other branches:

None

## Todos
- [X] Tests
- [X] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

1. run rake db:migrate

## Impacted Areas in Application
List general components of the application that this PR will affect:

* DB and seed file