### PR TITLE
Seed db

### DIFF
--- a/app/models/defense.rb
+++ b/app/models/defense.rb
@@ -1,0 +1,2 @@
+class Defense < ApplicationRecord
+end

--- a/app/models/defense.rb
+++ b/app/models/defense.rb
@@ -1,2 +1,4 @@
 class Defense < ApplicationRecord
+  validates :api_id, :name, :expected_point_production, presence: true
+  validates  :api_id, :name, uniqueness: true
 end

--- a/app/models/defense_calculator.rb
+++ b/app/models/defense_calculator.rb
@@ -13,6 +13,7 @@ class DefenseCalculator
   end
 
   def average_points
-    point_production_list.sum / point_production_list.count.to_f
+    total = point_production_list.sum { |num| num.to_f }
+    (total / point_production_list.count).round(2)
   end
 end

--- a/app/models/defense_calculator.rb
+++ b/app/models/defense_calculator.rb
@@ -1,0 +1,18 @@
+class DefenseCalculator
+  attr_reader :id, :name
+  attr_accessor :point_production_list
+
+  def initialize(attrs)
+    @id                    = attrs[:ID]
+    @name                  = attrs[:Name]
+    @point_production_list = []
+  end
+
+  def add_points(points)
+    point_production_list << points
+  end
+
+  def average_points
+    point_production_list.sum / point_production_list.count.to_f
+  end
+end

--- a/app/models/football_player.rb
+++ b/app/models/football_player.rb
@@ -1,2 +1,6 @@
 class FootballPlayer < ApplicationRecord
+  validates :api_id, :first_name, :last_name, :position,
+    :expected_point_production, presence: true
+
+  validates :api_id, uniqueness: true
 end

--- a/app/models/game_schedule.rb
+++ b/app/models/game_schedule.rb
@@ -4,6 +4,7 @@ class GameSchedule
   def initialize
     @games = []
     @seasons = ['2014-2014-regular', '2015-2015-regular', '2016-2016-regular']
+    # @seasons = ['2014-2014-regular'] truncated for testing
   end
 
   def store_schedule
@@ -15,9 +16,6 @@ class GameSchedule
       games.each do |game_details|
         @games << FootballGame.new(game_details)
       end
-      # @games = games.map do |game_details|
-      #   FootballGame.new(game_details)
-      # end
     end
   end
 end

--- a/app/models/player_stats.rb
+++ b/app/models/player_stats.rb
@@ -1,6 +1,7 @@
 class PlayerStats
   attr_reader :pass_yards, :pass_tds, :pass_ints, :rush_yards, :rush_tds,
-              :receptions, :rec_yards, :fum_lost, :kick_ret_td, :punt_ret_td
+              :receptions, :rec_yards, :fum_lost, :kick_ret_td, :punt_ret_td,
+              :rec_tds
 
   def initialize(attrs)
     @pass_yards  = attrs[:PassYards]
@@ -8,6 +9,7 @@ class PlayerStats
     @pass_ints   = attrs[:PassInt]
     @rush_yards  = attrs[:RushYards]
     @rush_tds    = attrs[:RushTD]
+    @rec_tds     = attrs[:RecTD]
     @receptions  = attrs[:Receptions]
     @rec_yards   = attrs[:RecYards]
     @fum_lost    = attrs[:FumLost]
@@ -16,19 +18,3 @@ class PlayerStats
   end
 
 end
-
-# 300+ Passing Yards	3	0
-# 100+ Yard Receiving Game	3	0
-# 2 Point Conversion	2	2
-# Sack	1	1
-# Interception	2	2
-# Fumble Recovery	2	2
-# Safety	2	2
-# Blocked Kick	2	2
-# 0 Pts Allowed	10	10
-# 1-6 Points Allowed	7	7
-# 7-13 Pts Allowed	4	4
-# 14-20 Pts Allowed	1	1
-# 21-27 Pts Allowed	0	0
-# 28-34 Pts Allowed	-1	-1
-# 35+ Pts Allowed	-4	-4

--- a/app/models/player_stats.rb
+++ b/app/models/player_stats.rb
@@ -3,6 +3,22 @@ class PlayerStats
               :receptions, :rec_yards, :fum_lost, :kick_ret_td, :punt_ret_td,
               :rec_tds
 
+  FANTASY_POINTS = {
+    "pass_tds": 4,
+    "pass_yards": 0.04,
+    "pass_ints": -1,
+    "rec_tds": 6,
+    "rec_yards": 0.1,
+    "receptions": 1,
+    "rush_tds": 6,
+    "rush_yards": 0.1,
+    "punt_ret_td": 6,
+    "kick_ret_td": 6,
+    "fum_lost": -1,
+    "pass_yards_300": 3,
+    "rush_or_rec_yards_100": 3
+  }
+
   def initialize(attrs)
     @pass_yards  = attrs[:PassYards]
     @pass_tds    = attrs[:PassTD]
@@ -15,6 +31,35 @@ class PlayerStats
     @fum_lost    = attrs[:FumLost]
     @kick_ret_td = attrs[:KrTD]
     @punt_ret_td = attrs[:PrTD]
+  end
+
+  def self.calculate_expected_point_production(stat)
+    expected_production = 0
+    expected_production += (stat.pass_tds[:"#text"].to_i * FANTASY_POINTS[:pass_tds])
+    expected_production += (stat.pass_yards[:"#text"].to_i * FANTASY_POINTS[:pass_yards])
+    expected_production += (stat.pass_ints[:"#text"].to_i * FANTASY_POINTS[:pass_ints])
+    expected_production += (stat.rec_tds[:"#text"].to_i * FANTASY_POINTS[:rec_tds])
+    expected_production += (stat.rec_yards[:"#text"].to_i * FANTASY_POINTS[:rec_yards])
+    expected_production += (stat.receptions[:"#text"].to_i * FANTASY_POINTS[:receptions])
+    expected_production += (stat.rush_tds[:"#text"].to_i * FANTASY_POINTS[:rush_tds])
+    expected_production += (stat.rush_yards[:"#text"].to_i * FANTASY_POINTS[:rush_yards])
+    expected_production += (stat.punt_ret_td[:"#text"].to_i * FANTASY_POINTS[:punt_ret_td])
+    expected_production += (stat.kick_ret_td[:"#text"].to_i * FANTASY_POINTS[:kick_ret_td])
+    expected_production += (stat.fum_lost[:"#text"].to_i * FANTASY_POINTS[:fum_lost])
+
+    if (stat.pass_yards[:"#text"].to_i >= 300)
+      expected_production += FANTASY_POINTS[:pass_yards_300]
+    end
+    
+    if (stat.pass_yards[:"#text"].to_i >= 100)
+      expected_production += FANTASY_POINTS[:rush_or_rec_yards_100]
+    end
+    
+    if (stat.rush_yards[:"#text"].to_i >= 100)
+      expected_production += FANTASY_POINTS[:rush_or_rec_yards_100]
+    end
+    
+    expected_production
   end
 
 end

--- a/app/services/sports_feed_service.rb
+++ b/app/services/sports_feed_service.rb
@@ -1,7 +1,6 @@
 require 'base64'
 require 'faraday'
 require 'json'
-require 'pry'
 
 class SportsFeedService
 
@@ -38,7 +37,6 @@ class SportsFeedService
   end
 
   def daily_fantasy_points(season)
-    # season = "#{year}-#{year}-regular"
     url = "/v1.1/pull/nfl/#{season}/daily_dfs.json"
     response = conn.get(url)
 

--- a/app/services/sports_feed_service.rb
+++ b/app/services/sports_feed_service.rb
@@ -37,6 +37,14 @@ class SportsFeedService
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  def daily_fantasy_points(season)
+    # season = "#{year}-#{year}-regular"
+    url = "/v1.1/pull/nfl/#{season}/daily_dfs.json"
+    response = conn.get(url)
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
   private
     attr_reader :conn
 end

--- a/db/migrate/20170906194250_create_defenses.rb
+++ b/db/migrate/20170906194250_create_defenses.rb
@@ -1,0 +1,11 @@
+class CreateDefenses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :defenses do |t|
+      t.text :api_id
+      t.text :name
+      t.text :expected_point_production
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904214919) do
+ActiveRecord::Schema.define(version: 20170906194250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "defenses", force: :cascade do |t|
+    t.text "api_id"
+    t.text "name"
+    t.text "expected_point_production"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "football_players", force: :cascade do |t|
     t.text "api_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,11 +13,10 @@ class Seed
     "rush_yards": 0.1,
     "punt_ret_td": 6,
     "kick_ret_td": 6,
-    "fum_lost": -1
+    "fum_lost": -1,
+    "pass_yards_300": 3,
+    "rush_or_rec_yards_100": 3
   }
-
-  # 300+ Passing Yards	3	0
-  # 100+ Yard Receiving Game	3	0
 
   def self.start
     schedule = GameSchedule.new
@@ -42,20 +41,49 @@ class Seed
     end
     puts "All stats done\r"
 
-    # players.each do |id, player|
-    #   binding.pry
+    players.each do |id, player|
 
-    #   football_player = FootballPlayer.new(
-    #     api_id: id, first_name: player.first_name, last_name: player.last_name,
-    #     position: player.position
-    #     )
+      football_player = FootballPlayer.new(
+        api_id: id, first_name: player.first_name, last_name: player.last_name,
+        position: player.position
+        )
 
-    #   player.stats.each do |stat|
-    #     expected_production = 0
+      expected_production_list = []
+      player.stats.each do |stat|
+        expected_production = 0
+        expected_production += (stat.pass_tds[:"#text"].to_i * FANTASY_POINTS[:pass_tds])
+        expected_production += (stat.pass_yards[:"#text"].to_i * FANTASY_POINTS[:pass_yards])
+        expected_production += (stat.pass_ints[:"#text"].to_i * FANTASY_POINTS[:pass_ints])
+        expected_production += (stat.rec_tds[:"#text"].to_i * FANTASY_POINTS[:rec_tds])
+        expected_production += (stat.rec_yards[:"#text"].to_i * FANTASY_POINTS[:rec_yards])
+        expected_production += (stat.receptions[:"#text"].to_i * FANTASY_POINTS[:receptions])
+        expected_production += (stat.rush_tds[:"#text"].to_i * FANTASY_POINTS[:rush_tds])
+        expected_production += (stat.rush_yards[:"#text"].to_i * FANTASY_POINTS[:rush_yards])
+        expected_production += (stat.punt_ret_td[:"#text"].to_i * FANTASY_POINTS[:punt_ret_td])
+        expected_production += (stat.kick_ret_td[:"#text"].to_i * FANTASY_POINTS[:kick_ret_td])
+        expected_production += (stat.fum_lost[:"#text"].to_i * FANTASY_POINTS[:fum_lost])
 
-    #   end
-    # end
-    # binding.pry
+        if (stat.pass_yards[:"#text"].to_i >= 300)
+          expected_production += FANTASY_POINTS[:pass_yards_300]
+        end
+        
+        if (stat.pass_yards[:"#text"].to_i >= 100)
+          expected_production += FANTASY_POINTS[:rush_or_rec_yards_100]
+        end
+        
+        if (stat.rush_yards[:"#text"].to_i >= 100)
+          expected_production += FANTASY_POINTS[:rush_or_rec_yards_100]
+        end
+        
+        expected_production_list << expected_production
+      end
+
+      avg_point_production = (expected_production_list.sum / expected_production_list.count.to_f)
+
+      football_player.update(expected_point_production: avg_point_production)
+      status = football_player.save
+      puts status
+    end
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,22 +2,6 @@ require 'pry'
 
 class Seed
 
-  FANTASY_POINTS = {
-    "pass_tds": 4,
-    "pass_yards": 0.04,
-    "pass_ints": -1,
-    "rec_tds": 6,
-    "rec_yards": 0.1,
-    "receptions": 1,
-    "rush_tds": 6,
-    "rush_yards": 0.1,
-    "punt_ret_td": 6,
-    "kick_ret_td": 6,
-    "fum_lost": -1,
-    "pass_yards_300": 3,
-    "rush_or_rec_yards_100": 3
-  }
-
   def self.start
     schedule = GameSchedule.new
     schedule.store_schedule
@@ -50,35 +34,12 @@ class Seed
 
       expected_production_list = []
       player.stats.each do |stat|
-        expected_production = 0
-        expected_production += (stat.pass_tds[:"#text"].to_i * FANTASY_POINTS[:pass_tds])
-        expected_production += (stat.pass_yards[:"#text"].to_i * FANTASY_POINTS[:pass_yards])
-        expected_production += (stat.pass_ints[:"#text"].to_i * FANTASY_POINTS[:pass_ints])
-        expected_production += (stat.rec_tds[:"#text"].to_i * FANTASY_POINTS[:rec_tds])
-        expected_production += (stat.rec_yards[:"#text"].to_i * FANTASY_POINTS[:rec_yards])
-        expected_production += (stat.receptions[:"#text"].to_i * FANTASY_POINTS[:receptions])
-        expected_production += (stat.rush_tds[:"#text"].to_i * FANTASY_POINTS[:rush_tds])
-        expected_production += (stat.rush_yards[:"#text"].to_i * FANTASY_POINTS[:rush_yards])
-        expected_production += (stat.punt_ret_td[:"#text"].to_i * FANTASY_POINTS[:punt_ret_td])
-        expected_production += (stat.kick_ret_td[:"#text"].to_i * FANTASY_POINTS[:kick_ret_td])
-        expected_production += (stat.fum_lost[:"#text"].to_i * FANTASY_POINTS[:fum_lost])
-
-        if (stat.pass_yards[:"#text"].to_i >= 300)
-          expected_production += FANTASY_POINTS[:pass_yards_300]
-        end
-        
-        if (stat.pass_yards[:"#text"].to_i >= 100)
-          expected_production += FANTASY_POINTS[:rush_or_rec_yards_100]
-        end
-        
-        if (stat.rush_yards[:"#text"].to_i >= 100)
-          expected_production += FANTASY_POINTS[:rush_or_rec_yards_100]
-        end
+        expected_production = PlayerStats.calculate_expected_point_production(stat)
         
         expected_production_list << expected_production
       end
 
-      avg_point_production = (expected_production_list.sum / expected_production_list.count.to_f)
+      avg_point_production = (expected_production_list.sum / expected_production_list.count.to_f).round(2)
 
       football_player.update(expected_point_production: avg_point_production)
       status = football_player.save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,7 +45,36 @@ class Seed
       status = football_player.save
       puts status
     end
+
+  end
+  
+  def self.defense
+    seasons = ['2014-2014-regular', '2015-2015-regular', '2016-2016-regular']
+    service = SportsFeedService.new
+    seasons.each do |season|
+      dfs_points = service.daily_fantasy_points(season)
+
+      dfs_all_players = dfs_points[:dailydfs][:dfsEntries][1][:dfsRows]
+
+      defenses = {}
+
+      dfs_all_players.each do |dfs_stat|
+        if dfs_stat[:player].nil?
+          defense_id = dfs_stat[:team][:ID]
+          if defenses[defense_id]
+            defense = defenses[defense_id]
+            defense.add_points(dfs_stat[:fantasyPoints])
+            defenses[defense_id] = defense
+          else
+            defense = DefenseCalculator.new(dfs_stat[:team])
+            defense.add_points(dfs_stat[:fantasyPoints])
+            defenses[defense_id] = defense
+          end
+        end
+      end
+    end
+    binding.pry
   end
 end
 
-Seed.start
+Seed.defense

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,12 +51,13 @@ class Seed
   def self.defense
     seasons = ['2014-2014-regular', '2015-2015-regular', '2016-2016-regular']
     service = SportsFeedService.new
+    defenses = {}
+
     seasons.each do |season|
       dfs_points = service.daily_fantasy_points(season)
 
       dfs_all_players = dfs_points[:dailydfs][:dfsEntries][1][:dfsRows]
 
-      defenses = {}
 
       dfs_all_players.each do |dfs_stat|
         if dfs_stat[:player].nil?
@@ -73,8 +74,13 @@ class Seed
         end
       end
     end
-    binding.pry
+
+    defenses.each do |id, team|
+      avg_points = team.average_points
+      Defense.create!(api_id: id, name: team.name, expected_point_production: avg_points)
+    end
   end
 end
 
+Seed.start
 Seed.defense

--- a/spec/factories/defenses.rb
+++ b/spec/factories/defenses.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :defense do
+    
+  end
+end

--- a/spec/models/defense_spec.rb
+++ b/spec/models/defense_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Defense, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/defense_spec.rb
+++ b/spec/models/defense_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Defense, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "valid attributes" do
+    it { should validate_presence_of(:api_id) }
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:expected_point_production) }
+
+    it { should validate_uniqueness_of(:api_id) }
+    it { should validate_uniqueness_of(:name) }
+  end
 end

--- a/spec/models/football_player_spec.rb
+++ b/spec/models/football_player_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe FootballPlayer, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "valid attributes" do
+    it { should validate_presence_of(:api_id) }
+    it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:last_name) }
+    it { should validate_presence_of(:position) }
+    it { should validate_presence_of(:expected_point_production) }
+
+    it { should validate_uniqueness_of(:api_id) }
+  end
 end


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
YES

## Description
PR now seeds all relevant player data from past three seasons. It also seeds fantasy point production for defenses averaged over the last three seasons as well. Next step is to get the current week's schedule and the starting players.



## Todos
- [X] Tests
- [X] Documentation
1. 

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Currently, only affects DB which stores two tables, football players and defenses.